### PR TITLE
erreur dans l'exemple du noyau de paramètre

### DIFF
--- a/R/main_before_utf.R
+++ b/R/main_before_utf.R
@@ -6071,7 +6071,7 @@ NULL
 #' p %>% iano_mco() -> ano
 #' p %>% ipo()      -> po
 #' 
-#' adezip(type = "in", liste = "")
+#' p %>% adezip(type = "in", liste = "")
 #'  
 #' p %>% irum()     -> rum
 #' 


### PR DESCRIPTION
coquille, noyau de paramètre manquant pour utilisation de la fonction adezip