### PR TITLE
VVR-fixes

### DIFF
--- a/R/VVR_HAD.R
+++ b/R/VVR_HAD.R
@@ -82,6 +82,7 @@ vvr_had_ght <- function(p, ghts, coeff_geo = 1.07, coeff_prudent = NULL){
     dplyr::mutate(anseqta = ifelse(mois_fin_ss_seq %in% c('01', '02'), p$annee - 1, p$annee) %>% as.character()) %>%
     dplyr::mutate(cgeo = coeff_geo,
            cprudent = case_when(
+             anseqta == '2023'    ~ 0.9930,
              anseqta == '2022'    ~ 0.9930,
              anseqta == '2021'    ~ 0.9930,
              anseqta == '2020'    ~ 0.9930,

--- a/R/VVR_MCO.R
+++ b/R/VVR_MCO.R
@@ -69,6 +69,7 @@ vvr_rsa.pm_param <- function(p, ...){
       TRUE ~ 1L
     )) %>% 
     dplyr::left_join(rsa$rsa_um %>% 
+                       dplyr::select_all(tolower) %>% 
                        dplyr::filter(substr(typaut1, 1, 2) == '07') %>% 
                        dplyr::distinct(cle_rsa) %>%
                        dplyr::mutate(uhcd = 1), by = 'cle_rsa') %>%
@@ -93,6 +94,7 @@ vvr_rsa.src <- function(con, an,  ...){
       TRUE ~ 1L
     )) %>% 
     dplyr::left_join(pmeasyr::tbl_mco(con, an, 'rsa_um') %>% 
+                       dplyr::select_all(tolower) %>% 
                        dplyr::filter(substr(typaut1, 1, 2) == '07') %>% 
                        dplyr::distinct(cle_rsa) %>%
                        dplyr::mutate(uhcd = 1), by = 'cle_rsa') %>%
@@ -301,7 +303,8 @@ vvr_ghs_supp <- function(rsa,
   if (is.null(prudent)) {
     rsa_2 <- rsa %>%
       dplyr::filter(substr(noghs,1,1) != 'I') %>%
-      dplyr::mutate(cprudent = dplyr::case_when(anseqta == "2022" ~ 0.993 * 1.0013,
+      dplyr::mutate(cprudent = dplyr::case_when(anseqta == "2023" ~ 0.993 * 1.0023,
+                                                anseqta == "2022" ~ 0.993 * 1.0013,
                                                 anseqta == "2021" ~ 0.993 * 1.0019, 
                                                 anseqta == "2020" ~ 0.993,
                                                 anseqta == "2019" ~ 0.993, anseqta == "2018" ~ 0.993,
@@ -319,7 +322,7 @@ vvr_ghs_supp <- function(rsa,
                                                                                             t_bas), rec_totale = rec_bee) %>%
       bind_rows(rsa %>%
                   dplyr::filter(substr(noghs,1,1) == 'I') %>%
-                  dplyr::mutate(cprudent = dplyr::case_when(anseqta == "2022" ~ 0.993, 
+                  dplyr::mutate(cprudent = dplyr::case_when(anseqta == "2023" ~ 0.993, anseqta == "2022" ~ 0.993, 
                                                             anseqta == "2021" ~ 0.993, anseqta == "2020" ~ 0.993,
                                                             anseqta == "2019" ~ 0.993, anseqta == "2018" ~ 0.993,
                                                             anseqta == "2017" ~ 0.993, anseqta == "2016" ~ 0.995,
@@ -333,9 +336,10 @@ vvr_ghs_supp <- function(rsa,
       dplyr::filter(substr(noghs,1,1) != 'I') %>%
       
       dplyr::mutate(cprudent = dplyr::case_when(
+        anseqta == "2023" ~ prudent * 1.0023,
         anseqta == "2022" ~ prudent * 1.0013,
         anseqta == "2021" ~ prudent * 1.0019,
-                                                TRUE ~ prudent)) %>% 
+        TRUE ~ prudent)) %>% 
       dplyr::left_join(tarifs %>%
                          dplyr::select(-ghm), by = c(noghs = "ghs", anseqta = "anseqta")) %>%
       dplyr::mutate(t_base = nbseance * tarif_base * cgeo * cprudent, 

--- a/R/VVR_MCO.R
+++ b/R/VVR_MCO.R
@@ -617,7 +617,7 @@ vvr_ghs_supp <- function(rsa,
 #' 
 #' 
 #' @param rsa un tibble rsa contenant les variables nécessaires (créé avec \code{\link{vvr_rsa}})
-#' @param ano un tibble ano contenant les variables nécessaires (créé avec \code{\link{vvr_mco_ano}})
+#' @param ano un tibble ano contenant les variables nécessaires (créé avec \code{\link{vvr_ano_mco}})
 #' @param porg un tibble porg contenant les prélevements d'organes du out (créé avec \code{\link{ipo}})
 #' 
 #' @return Un tibble contenant la catégorie du tableau SV epmsi, une ligne par clé rsa


### PR DESCRIPTION

Bonjour Guillaume,
j'ai corrigé un bug sur VVR_MCO qui plantait quand les noms de colonnes étaient en majuscules et j'en ai profité pour rajouter les coef prudentiel et segur 2023 dans les 2 VVR et fixer une typo sur vvr_mco_ano -> vvr_ano_mco.

Contributions modestes, mais il faut bien commencer par quelque chose de simple.

Cordialement
